### PR TITLE
enable manual runs of all github workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 jobs:
   run-linters:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -18,6 +18,7 @@ on:
       - "Dockerfile"
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
 
 env:
   # Use docker.io for Docker Hub if empty


### PR DESCRIPTION
This should enable us to manually run our workflows without requiring a PR/merge event.

See: https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
